### PR TITLE
Fix 'runs:' section is required msg

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ inputs:
 output:
   result:
     description: Boolean which indicates if the action was successful or not
+
 runs:
   using: node12
   main: main.js


### PR DESCRIPTION
Action is not working (probably) lately. For GitHub YAML parser there's need to be a new line before `runs` section otherwise end up with error:

```Top level 'runs:' section is required for /home/runner/work/_actions/sekassel-research/actions-rancher-update/1.0.0/action.yml```