### PR TITLE
Update to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ inputs:
     required: true
 
 runs:
-  using: node12
+  using: node16
   main: main.js


### PR DESCRIPTION
# Context
Node.js 12 actions are currently deprecated (see [blogpost](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) by GitHub). I don't expect the underlying source code to break from upgrading it to `node16`. However, it might be useful to bump the major version because older GitHub actions runners might not support node16.