### PR TITLE
Make retry count and delay into input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ This action helps by updating a service in the rancher 1.6.x environment.
           stack_name: test-stack
           service_name: test-service
           docker_image: sekassel-research/test-image:latest
-          retry_count: 10
-          retry_delay: 5
+          retry_count: 10 # optional
+          retry_delay: 5 # optional
 ```
 
 This will upgrade the service in Rancher and wait 5 seconds before

--- a/README.md
+++ b/README.md
@@ -25,5 +25,10 @@ This action helps by updating a service in the rancher 1.6.x environment.
           stack_name: test-stack
           service_name: test-service
           docker_image: sekassel-research/test-image:latest
-          
+          retry_count: 10
+          retry_delay: 5
 ```
+
+This will upgrade the service in Rancher and wait 5 seconds before
+trying to finish the upgrade. The action will wait 10 times before
+failing the job, if the upgrade is not successful.

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,12 @@ inputs:
   docker_image:
     description: Name of the docker image which is used for updating
     required: true
+  retry_count:
+    description: Maximum number of retries waiting for upgrade
+    required: true
+  retry_delay:
+    description: Timeout before retry waiting for upgrade
+    required: true
 output:
   result:
     description: Boolean which indicates if the action was successful or not

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,12 @@ inputs:
     required: true
   retry_count:
     description: Maximum number of retries waiting for upgrade
-    required: true
+    required: false
+    default: 10
   retry_delay:
     description: Timeout before retry waiting for upgrade
-    required: true
+    required: false
+    default: 5
 output:
   result:
     description: Boolean which indicates if the action was successful or not

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ const waitForState = async (waitFor, rancherApi, id, retryCount, retryDelay) => 
     await sleep(retryDelay);
   }
 
-  if (retry === 0) {
+  if (retryCount === 0) {
     throw new Error(`Maximum retries exceeded waiting for state ${waitFor}`);
   }
 }

--- a/main.js
+++ b/main.js
@@ -26,8 +26,8 @@ async function main() {
   const STACK_NAME = core.getInput('stack_name', { required: true });
   const SERVICE_NAME = core.getInput('service_name', { required: true });
   const DOCKER_IMAGE = core.getInput('docker_image', { required: true });
-  const RETRY_COUNT = core.getInput('retry_count', { required: true });
-  const RETRY_DELAY = core.getInput('retry_delay', { required: true });
+  const RETRY_COUNT = +core.getInput('retry_count');
+  const RETRY_DELAY = +core.getInput('retry_delay');
  
   const rancherApi = request.defaults({
     baseUrl: `${RANCHER_URL}/v2-beta/projects/${PROJECT_ID}`,

--- a/main.js
+++ b/main.js
@@ -5,13 +5,12 @@ process.on('unhandledRejection', handleError);
 main().catch(handleError);
 
 const sleep = (sec) => new Promise((resolve) => setTimeout(resolve, sec * 1000));
-const waitForState = async (waitFor, rancherApi, id, retry_count, retry_delay) => {
-  let retry = retry_count;
+const waitForState = async (waitFor, rancherApi, id, retryCount, retryDelay) => {
   let state = '';
-  while (state !== waitFor && retry > 0) {
+  while (state !== waitFor && retryCount > 0) {
     state = (await rancherApi.get(`/services/${id}`)).state;
-    retry--;
-    await sleep(retry_delay);
+    retryCount--;
+    await sleep(retryDelay);
   }
 
   if (retry === 0) {

--- a/main.js
+++ b/main.js
@@ -5,13 +5,13 @@ process.on('unhandledRejection', handleError);
 main().catch(handleError);
 
 const sleep = (sec) => new Promise((resolve) => setTimeout(resolve, sec * 1000));
-const waitForState = async (waitFor, rancherApi, id) => {
-  let retry = 10;
+const waitForState = async (waitFor, rancherApi, id, retry_count, retry_delay) => {
+  let retry = retry_count;
   let state = '';
   while (state !== waitFor && retry > 0) {
     state = (await rancherApi.get(`/services/${id}`)).state;
     retry--;
-    await sleep(5);
+    await sleep(retry_delay);
   }
 
   if (retry === 0) {
@@ -27,6 +27,8 @@ async function main() {
   const STACK_NAME = core.getInput('stack_name', { required: true });
   const SERVICE_NAME = core.getInput('service_name', { required: true });
   const DOCKER_IMAGE = core.getInput('docker_image', { required: true });
+  const RETRY_COUNT = core.getInput('retry_count', { required: true });
+  const RETRY_DELAY = core.getInput('retry_delay', { required: true });
  
   const rancherApi = request.defaults({
     baseUrl: `${RANCHER_URL}/v2-beta/projects/${PROJECT_ID}`,
@@ -61,12 +63,12 @@ async function main() {
   };
   await rancherApi.post(`/service/${id}?action=upgrade`, { body });
   console.log('Waiting for upgrade ...');
-  await waitForState('upgraded', rancherApi, id);
+  await waitForState('upgraded', rancherApi, id, RETRY_COUNT, RETRY_DELAY);
 
   // Finish upgrade
   await rancherApi.post(`/service/${id}?action=finishupgrade`);
   console.log('Waiting for service starting ...');
-  await waitForState('active', rancherApi, id);
+  await waitForState('active', rancherApi, id, RETRY_COUNT, RETRY_DELAY);
 
   console.log('Service is running, upgrade successful');
   core.setOutput('result', success);


### PR DESCRIPTION
Adds to new input parameters:

- `retry_count`: Maximum number of retries waiting for upgrade
- `retry_delay`: Timeout before retry waiting for upgrade

Those options may be useful for people still using Rancher 1.x.

Fixes #8 